### PR TITLE
Fix `IsValidPhoneNumber` validating against the email pattern

### DIFF
--- a/src/Solhigson.Utilities.Tests/HelperFunctionsTests.cs
+++ b/src/Solhigson.Utilities.Tests/HelperFunctionsTests.cs
@@ -1,0 +1,28 @@
+using Shouldly;
+using Xunit;
+
+namespace Solhigson.Utilities.Tests;
+
+public class HelperFunctionsTests
+{
+    // --- IsValidPhoneNumber ---
+
+    [Theory]
+    [InlineData("08031234567")]
+    [InlineData("+2348031234567")]
+    [InlineData("0803 123 4567")]
+    [InlineData("+234 803 123 456")]
+    public void IsValidPhoneNumber_ValidNumber_ReturnsTrue(string phoneNumber)
+    {
+        HelperFunctions.IsValidPhoneNumber(phoneNumber).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("not-a-number")]
+    [InlineData("123")]
+    [InlineData("test@example.com")]
+    public void IsValidPhoneNumber_InvalidNumber_ReturnsFalse(string phoneNumber)
+    {
+        HelperFunctions.IsValidPhoneNumber(phoneNumber).ShouldBeFalse();
+    }
+}

--- a/src/Solhigson.Utilities/HelperFunctions.cs
+++ b/src/Solhigson.Utilities/HelperFunctions.cs
@@ -62,12 +62,12 @@ public static class HelperFunctions
         @"\A(?:[a-z0-9A-Z!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9A-Z](?:[a-zA-Z0-9-]*[A-Za-z0-9])?\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)\Z";
 
     public const string MatchPhoneNumberPattern =
-        @"^\\+?[0-9 ]{11,15}$";
+        @"^\+?[0-9 ]{11,15}$";
 
     private static readonly Regex EmailMatchRegex = new Regex(MatchEmailPattern,
         RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
-    private static readonly Regex PhoneNumberMatchRegex = new Regex(MatchEmailPattern,
+    private static readonly Regex PhoneNumberMatchRegex = new Regex(MatchPhoneNumberPattern,
         RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     public static bool IsValidEmailAddress(string email, bool ignoreEmpty = false)


### PR DESCRIPTION
## Problem

`HelperFunctions.IsValidPhoneNumber` (and the `string.IsValidPhoneNumber` extension) was silently running **email** validation.

`PhoneNumberMatchRegex` was constructed from `MatchEmailPattern` instead of `MatchPhoneNumberPattern`:

```csharp
private static readonly Regex PhoneNumberMatchRegex = new Regex(MatchEmailPattern, ...);
```

Consequences:
- Valid phone numbers (`08031234567`, `+2348031234567`) were rejected.
- Email addresses (`test@example.com`) were accepted as valid phone numbers.

A second, latent defect: `MatchPhoneNumberPattern` itself was `@"^\+?[0-9 ]{11,15}$"`. The `\+` matches a *literal backslash* followed by `+`, not an optional leading `+`, so even the correct constant would not have accepted `+234...` forms.

## Fix

- Point `PhoneNumberMatchRegex` at `MatchPhoneNumberPattern`.
- Correct the pattern to `@"^\+?[0-9 ]{11,15}$"` (optional leading `+`).

Two-line change, no behaviour change to the 11-to-15 length contract.

## Tests

Added `HelperFunctionsTests` (xUnit + Shouldly, matching the existing test style) covering local, international, and spaced formats plus non-numeric and email inputs. Full `Solhigson.Utilities.Tests` suite passes (41/41).

No `PackageVersion` bump - left for the maintainer's release flow.